### PR TITLE
Only install krb5 on linux

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - ruamel.yaml
   run_constrained:
     - python-gssapi >=1.6.0  # [not win]
-    - krb5 >=0.3.0  # [not win]
+    - krb5 >=0.3.0  # [linux]
 
 test:
   imports:


### PR DESCRIPTION
This practically only changes mac - which has the heimdal implementation of Kerberos installed by default